### PR TITLE
Add graphical interface for process simulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.txt
+++ b/README.txt
@@ -1,0 +1,65 @@
+Process Flow Monte Carlo Simulator
+==================================
+
+This repository now includes an interactive application for analysing serial
+process lines with Monte Carlo simulation. A polished graphical interface helps
+non-technical stakeholders explore scenarios visually and compare performance at
+a glance.
+
+Quick start
+-----------
+
+1. Ensure you are using Python 3.9+.
+2. Install the GUI dependency:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. From the repository root, launch the simulator:
+
+   ```bash
+   python run_simulator.py
+   ```
+
+4. Use the setup tab to choose the provided Line A/Line B examples or create your
+   own process configuration. Adjust buffer capacities and Monte Carlo settings,
+   then run the simulation to visualise throughput and workstation behaviour.
+
+Capabilities
+------------
+
+* Configure multiple production lines side-by-side with an intuitive workstation
+  table and buffer controls.
+* Choose from several processing-time distributions (uniform, triangular, normal,
+  lognormal, exponential) per workstation via guided dialogs.
+* Control buffer capacities (0, finite, or effectively infinite) between
+  workstations.
+* Tune the Monte Carlo run length (warm-up jobs, observed jobs, number of
+  replications, and random seed) directly from the setup screen.
+* Review throughput and cycle-time summaries in an interactive results tab with
+  comparison charts and per-station utilisation, blocked, and starved metrics.
+* Run an automated buffer impact study that evaluates each potential buffer
+  location and recommends the placement that yields the largest throughput gain.
+
+Answering the prompt's question
+-------------------------------
+
+To replicate the example in the prompt:
+
+1. Launch the simulator and choose the sample configurations for Line A and Line B.
+2. Use the default simulation settings or adjust them as desired.
+3. After the Monte Carlo results are displayed, use the buffer study controls on the
+   results tab to evaluate adding a buffer and review the recommended location.
+
+File overview
+-------------
+
+* `run_simulator.py` – entry point script.
+* `simulator/` – Python package with the simulation engine and user interfaces.
+  * `distributions.py` – user-friendly distribution helpers.
+  * `entities.py` – task and process-line models.
+  * `simulation.py` – discrete event simulation core.
+  * `monte_carlo.py` – Monte Carlo orchestration helpers.
+  * `gui.py` – Tkinter-based graphical interface with visual reporting.
+  * `app.py` – original command-line interface (kept for reference).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+matplotlib>=3.8

--- a/run_simulator.py
+++ b/run_simulator.py
@@ -1,0 +1,6 @@
+"""Launch the graphical process flow simulator."""
+from simulator.gui import launch
+
+
+if __name__ == "__main__":
+    launch()

--- a/simulator/__init__.py
+++ b/simulator/__init__.py
@@ -1,0 +1,17 @@
+"""Process flow simulation package."""
+
+from .distributions import DistributionConfig, DistributionFactory
+from .entities import Task, ProcessLine
+from .monte_carlo import MonteCarloResult, MonteCarloSummary
+from .simulation import SimulationConfig, simulate_line
+
+__all__ = [
+    "DistributionConfig",
+    "DistributionFactory",
+    "Task",
+    "ProcessLine",
+    "MonteCarloResult",
+    "MonteCarloSummary",
+    "SimulationConfig",
+    "simulate_line",
+]

--- a/simulator/app.py
+++ b/simulator/app.py
@@ -1,0 +1,261 @@
+"""Interactive command-line application for the process flow simulator."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from .distributions import DistributionFactory
+from .entities import ProcessLine, Task, infinite_buffer
+from .monte_carlo import MonteCarloResult, MonteCarloSummary, run_monte_carlo, summarize_results
+
+
+@dataclass
+class LineInput:
+    name: str
+    tasks: List[Task]
+    buffers: List[Optional[int]]
+
+
+SAMPLE_LINES: Dict[str, LineInput] = {}
+
+
+def _build_sample_lines() -> None:
+    global SAMPLE_LINES
+    if SAMPLE_LINES:
+        return
+    line_a_tasks = [
+        Task(name=f"Task {i+1}", distribution=DistributionFactory.from_dict({"type": "uniform", "mean": 10, "half_range": 2}))
+        for i in range(6)
+    ]
+    line_b_distributions = [
+        {"type": "uniform", "mean": 6, "half_range": 2},
+        {"type": "uniform", "mean": 10, "half_range": 2},
+        {"type": "uniform", "mean": 4, "half_range": 3},
+        {"type": "uniform", "mean": 7, "half_range": 1},
+        {"type": "uniform", "mean": 5, "half_range": 3},
+        {"type": "uniform", "mean": 5, "half_range": 2},
+    ]
+    line_b_tasks = [Task(name=f"Task {idx+1}", distribution=DistributionFactory.from_dict(dist)) for idx, dist in enumerate(line_b_distributions)]
+    line_a = LineInput(name="Line A", tasks=line_a_tasks, buffers=[0] * (len(line_a_tasks) - 1))
+    line_b = LineInput(name="Line B", tasks=line_b_tasks, buffers=[0] * (len(line_b_tasks) - 1))
+    SAMPLE_LINES = {line_a.name: line_a, line_b.name: line_b}
+
+
+def _input_with_default(prompt: str, default: Optional[str] = None) -> str:
+    suffix = f" [{default}]" if default is not None else ""
+    response = input(f"{prompt}{suffix}: ").strip()
+    if not response and default is not None:
+        return default
+    return response
+
+
+def _prompt_float(prompt: str, default: float) -> float:
+    while True:
+        response = _input_with_default(prompt, f"{default}")
+        try:
+            return float(response)
+        except ValueError:
+            print("Please enter a numeric value.")
+
+
+def _prompt_int(prompt: str, default: int, minimum: int = 0) -> int:
+    while True:
+        response = _input_with_default(prompt, f"{default}")
+        try:
+            value = int(float(response))
+            if value < minimum:
+                raise ValueError
+            return value
+        except ValueError:
+            print(f"Please enter an integer greater than or equal to {minimum}.")
+
+
+def _prompt_choice(prompt: str, options: List[str], default: Optional[str] = None) -> str:
+    option_map = {str(i + 1): opt for i, opt in enumerate(options)}
+    while True:
+        for idx, option in enumerate(options, start=1):
+            marker = "" if default != option else " (default)"
+            print(f"  {idx}. {option}{marker}")
+        response = _input_with_default(prompt, None if default is None else str(options.index(default) + 1))
+        chosen = option_map.get(response)
+        if chosen:
+            return chosen
+        print("Please select one of the listed options by number.")
+
+
+def _prompt_distribution(default_type: str = "uniform") -> Task:
+    dist_types = ["Uniform", "Triangular", "Normal", "LogNormal", "Exponential"]
+    chosen_type = _prompt_choice("Select distribution type", dist_types, default=default_type.title())
+    dist_key = chosen_type.lower()
+    if dist_key == "uniform":
+        mean = _prompt_float("  Mean processing time", 10.0)
+        half_range = _prompt_float("  Range (half-width)", 2.0)
+        distribution = DistributionFactory.from_dict({"type": "uniform", "mean": mean, "half_range": half_range})
+    elif dist_key == "triangular":
+        minimum = _prompt_float("  Minimum", 5.0)
+        mode = _prompt_float("  Most likely", (minimum + 10.0) / 2)
+        maximum = _prompt_float("  Maximum", maximum := max(minimum + 1.0, mode + 1.0))
+        distribution = DistributionFactory.from_dict({"type": "triangular", "min": minimum, "mode": mode, "max": maximum})
+    elif dist_key == "normal":
+        mean = _prompt_float("  Mean processing time", 10.0)
+        stdev = _prompt_float("  Standard deviation", max(0.1, mean * 0.1))
+        distribution = DistributionFactory.from_dict({"type": "normal", "mean": mean, "stdev": stdev})
+    elif dist_key == "lognormal":
+        mean = _prompt_float("  Mean processing time", 10.0)
+        stdev = _prompt_float("  Standard deviation", max(0.1, mean * 0.2))
+        distribution = DistributionFactory.from_dict({"type": "lognormal", "mean": mean, "stdev": stdev})
+    else:
+        mean = _prompt_float("  Mean processing time", 10.0)
+        distribution = DistributionFactory.from_dict({"type": "exponential", "mean": mean})
+    name = _input_with_default("  Task name", "Task")
+    return Task(name=name or "Task", distribution=distribution)
+
+
+def build_line_from_user(index: int) -> LineInput:
+    print(f"\nConfiguring line #{index}...")
+    name = _input_with_default("Line name", f"Line {index}")
+    task_count = _prompt_int("How many workstations?", 3, minimum=1)
+    tasks: List[Task] = []
+    for task_index in range(task_count):
+        print(f"Define workstation {task_index + 1}:")
+        task = _prompt_distribution()
+        if task.name == "Task":
+            task.name = f"Task {task_index + 1}"
+        tasks.append(task)
+    buffers: List[Optional[int]] = []
+    for buffer_index in range(task_count - 1):
+        default_capacity = "0"
+        response = _input_with_default(
+            f"Buffer between {tasks[buffer_index].name} and {tasks[buffer_index + 1].name} (0, positive integer, or 'inf')",
+            default_capacity,
+        )
+        if response.lower() in {"inf", "infinite", "infinity"}:
+            buffers.append(infinite_buffer())
+        else:
+            try:
+                capacity = int(float(response))
+                if capacity < 0:
+                    raise ValueError
+                buffers.append(capacity)
+            except ValueError:
+                print("Invalid value, using 0 (no buffer).")
+                buffers.append(0)
+    return LineInput(name=name, tasks=tasks, buffers=buffers)
+
+
+def select_line_from_samples() -> LineInput:
+    _build_sample_lines()
+    options = list(SAMPLE_LINES.keys())
+    chosen = _prompt_choice("Choose a sample line", options, default=options[0])
+    return SAMPLE_LINES[chosen]
+
+
+def configure_lines() -> List[LineInput]:
+    print("Welcome to the Process Flow Monte Carlo Simulator!")
+    print("You can load one of the ready-to-run examples or create your own process line definition.\n")
+    number_of_lines = _prompt_int("How many lines would you like to simulate?", 2, minimum=1)
+    lines: List[LineInput] = []
+    for idx in range(1, number_of_lines + 1):
+        print(f"\nLine #{idx}")
+        choice = _prompt_choice("Use a sample or build custom?", ["Sample line", "Create manually"], default="Sample line")
+        if choice == "Sample line":
+            selected = select_line_from_samples()
+            lines.append(LineInput(name=selected.name, tasks=list(selected.tasks), buffers=list(selected.buffers)))
+        else:
+            lines.append(build_line_from_user(idx))
+    return lines
+
+
+def _format_value(value: float, unit: str = "") -> str:
+    if math.isnan(value) or math.isinf(value):
+        return "-"
+    return f"{value:8.3f}{unit}"
+
+
+def _print_line_summary(summary: MonteCarloSummary) -> None:
+    print(f"\n=== {summary.line_name} ===")
+    print(f"Throughput (jobs/min): {_format_value(summary.throughput_mean)} ± {_format_value(summary.throughput_std)}")
+    print(f"Avg cycle time (min): {_format_value(summary.cycle_time_mean)} ± {_format_value(summary.cycle_time_std)}")
+    print("Station performance:")
+    header = f"{'Station':<20}{'Util%':>10}{'Blocked%':>12}{'Starved%':>12}"
+    print(header)
+    print("-" * len(header))
+    for name in summary.station_utilization.keys():
+        util = summary.station_utilization.get(name, 0.0) * 100
+        blocked = summary.station_blocked.get(name, 0.0) * 100
+        starved = summary.station_starved.get(name, 0.0) * 100
+        print(f"{name:<20}{util:10.1f}{blocked:12.1f}{starved:12.1f}")
+
+
+def _compare_throughput(summaries: List[MonteCarloSummary]) -> None:
+    if len(summaries) < 2:
+        return
+    print("\nThroughput comparison (higher is better):")
+    reference = max(summaries, key=lambda s: s.throughput_mean).throughput_mean
+    for summary in summaries:
+        delta = summary.throughput_mean - reference
+        indicator = "*" if abs(delta) < 1e-6 else ("+" if delta > 0 else "-")
+        print(f"  {summary.line_name:<20} {_format_value(summary.throughput_mean)} ({indicator}{delta:0.3f})")
+
+
+def _run_buffer_study(line: LineInput, jobs: int, warmup: int, sims: int) -> None:
+    if len(line.tasks) < 2:
+        print("Buffer study requires at least two workstations.")
+        return
+    base_line = ProcessLine(name=line.name, tasks=line.tasks, buffer_capacities=line.buffers)
+    baseline_result = MonteCarloSummary.from_result(run_monte_carlo(base_line, jobs, warmup, sims))
+    print(f"\nBuffer impact study for {line.name}")
+    base_throughput = baseline_result.throughput_mean
+    print(f"  Baseline throughput: {base_throughput:.3f} jobs/min")
+    candidate_capacity = _prompt_int("  Capacity of the new buffer (use a large number for \"infinite\")", 1, minimum=1)
+    best_delta = float("-inf")
+    best_location = None
+    for idx in range(len(line.tasks) - 1):
+        modified_buffers = list(line.buffers)
+        modified_buffers[idx] = candidate_capacity
+        modified_line = ProcessLine(name=f"{line.name} + buffer {idx+1}", tasks=line.tasks, buffer_capacities=modified_buffers)
+        result = MonteCarloSummary.from_result(run_monte_carlo(modified_line, jobs, warmup, sims))
+        delta = result.throughput_mean - base_throughput
+        print(f"    Between {line.tasks[idx].name} and {line.tasks[idx+1].name}: throughput {result.throughput_mean:.3f} (Δ {delta:+.3f})")
+        if delta > best_delta:
+            best_delta = delta
+            best_location = idx
+    if best_location is None or best_delta <= 1e-6:
+        print("  No buffer location provided a meaningful improvement.")
+    else:
+        print(
+            f"  Suggested location: between {line.tasks[best_location].name} and {line.tasks[best_location + 1].name} "
+            f"(Δ throughput {best_delta:+.3f} jobs/min)"
+        )
+
+
+def main() -> None:
+    lines = configure_lines()
+    jobs = _prompt_int("How many jobs should be observed (after warm-up)?", 500, minimum=1)
+    warmup = _prompt_int("Warm-up jobs to discard?", 100, minimum=0)
+    sims = _prompt_int("Number of Monte Carlo simulations?", 25, minimum=1)
+    base_seed_input = _input_with_default("Random seed (leave blank for random)", "")
+    base_seed = int(base_seed_input) if base_seed_input else None
+
+    monte_results: List[MonteCarloResult] = []
+    for line in lines:
+        process_line = ProcessLine(name=line.name, tasks=line.tasks, buffer_capacities=line.buffers)
+        result = run_monte_carlo(process_line, jobs_to_complete=jobs, warmup_jobs=warmup, simulations=sims, base_seed=base_seed)
+        monte_results.append(result)
+
+    summaries = summarize_results(monte_results)
+    for summary in summaries:
+        _print_line_summary(summary)
+    _compare_throughput(summaries)
+
+    for line in lines:
+        response = _input_with_default(f"\nRun a buffer impact study for {line.name}? (y/n)", "n").lower()
+        if response.startswith("y"):
+            _run_buffer_study(line, jobs, warmup, sims)
+
+    print("\nSimulation complete. Thank you for using the Process Flow Monte Carlo Simulator!")
+
+
+if __name__ == "__main__":
+    main()

--- a/simulator/distributions.py
+++ b/simulator/distributions.py
@@ -1,0 +1,158 @@
+"""Probability distribution helpers for the process simulator."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+import random
+from typing import Callable, Dict, Optional
+
+
+@dataclass
+class DistributionConfig:
+    """User friendly specification of a probability distribution."""
+
+    type: str
+    parameters: Dict[str, float]
+
+    def describe(self) -> str:
+        items = ", ".join(f"{k}={v}" for k, v in self.parameters.items())
+        return f"{self.type.title()}({items})"
+
+
+class Distribution:
+    """Base distribution interface."""
+
+    def __init__(self, sampler: Callable[[random.Random], float], description: str) -> None:
+        self._sampler = sampler
+        self.description = description
+
+    def sample(self, rng: random.Random) -> float:
+        value = self._sampler(rng)
+        return max(0.0, value)
+
+
+class DistributionFactory:
+    """Factory for constructing distributions from configuration dictionaries."""
+
+    SUPPORTED_TYPES = {"uniform", "triangular", "normal", "lognormal", "exponential"}
+
+    @staticmethod
+    def from_config(config: DistributionConfig) -> Distribution:
+        dist_type = config.type.lower().strip()
+        params = config.parameters
+        if dist_type == "uniform":
+            mean = params.get("mean")
+            half_range = params.get("half_range")
+            if mean is None or half_range is None:
+                raise ValueError("Uniform distribution requires 'mean' and 'half_range'.")
+            low = mean - half_range
+            high = mean + half_range
+            description = f"Uniform({low:.2f}, {high:.2f})"
+
+            def sampler(rng: random.Random) -> float:
+                return rng.uniform(low, high)
+
+            return Distribution(sampler, description)
+
+        if dist_type == "triangular":
+            low = params.get("min")
+            mode = params.get("mode")
+            high = params.get("max")
+            if low is None or mode is None or high is None:
+                raise ValueError("Triangular distribution requires 'min', 'mode', and 'max'.")
+            description = f"Triangular({low:.2f}, {mode:.2f}, {high:.2f})"
+
+            def sampler(rng: random.Random) -> float:
+                return rng.triangular(low, high, mode)
+
+            return Distribution(sampler, description)
+
+        if dist_type == "normal":
+            mean = params.get("mean")
+            stdev = params.get("stdev")
+            if mean is None or stdev is None:
+                raise ValueError("Normal distribution requires 'mean' and 'stdev'.")
+            description = f"Normal(mean={mean:.2f}, stdev={stdev:.2f})"
+
+            def sampler(rng: random.Random) -> float:
+                return rng.gauss(mean, stdev)
+
+            return Distribution(sampler, description)
+
+        if dist_type == "lognormal":
+            mean = params.get("mean")
+            stdev = params.get("stdev")
+            if mean is None or stdev is None:
+                raise ValueError("Lognormal distribution requires 'mean' and 'stdev'.")
+            if mean <= 0:
+                raise ValueError("Lognormal mean must be positive.")
+            # Convert mean/stdev of raw distribution to mu/sigma of underlying normal
+            variance = stdev ** 2
+            phi = math.sqrt(variance + mean ** 2)
+            sigma = math.sqrt(math.log((phi ** 2) / (mean ** 2)))
+            mu = math.log(mean) - 0.5 * sigma ** 2
+            description = f"LogNormal(mean={mean:.2f}, stdev={stdev:.2f})"
+
+            def sampler(rng: random.Random) -> float:
+                return rng.lognormvariate(mu, sigma)
+
+            return Distribution(sampler, description)
+
+        if dist_type == "exponential":
+            mean = params.get("mean")
+            if mean is None:
+                raise ValueError("Exponential distribution requires 'mean'.")
+            if mean <= 0:
+                raise ValueError("Exponential mean must be positive.")
+            lambd = 1.0 / mean
+            description = f"Exponential(mean={mean:.2f})"
+
+            def sampler(rng: random.Random) -> float:
+                return rng.expovariate(lambd)
+
+            return Distribution(sampler, description)
+
+        raise ValueError(f"Unsupported distribution type '{config.type}'.")
+
+    @staticmethod
+    def from_dict(definition: Dict[str, float]) -> Distribution:
+        dist_type = definition.get("type")
+        if not dist_type:
+            raise ValueError("Distribution definition requires a 'type' field.")
+        params = {k: v for k, v in definition.items() if k != "type"}
+        return DistributionFactory.from_config(DistributionConfig(type=dist_type, parameters=params))
+
+
+def build_distribution_from_user_input(
+    dist_type: str,
+    mean: Optional[float] = None,
+    half_range: Optional[float] = None,
+    minimum: Optional[float] = None,
+    mode: Optional[float] = None,
+    maximum: Optional[float] = None,
+    stdev: Optional[float] = None,
+) -> Distribution:
+    """Helper for legacy callers to create a distribution directly."""
+
+    dist_type = dist_type.lower().strip()
+    if dist_type == "uniform":
+        if mean is None or half_range is None:
+            raise ValueError("Uniform distribution requires mean and half_range.")
+        return DistributionFactory.from_dict({"type": "uniform", "mean": mean, "half_range": half_range})
+    if dist_type == "triangular":
+        if minimum is None or mode is None or maximum is None:
+            raise ValueError("Triangular distribution requires min, mode, and max.")
+        return DistributionFactory.from_dict({"type": "triangular", "min": minimum, "mode": mode, "max": maximum})
+    if dist_type == "normal":
+        if mean is None or stdev is None:
+            raise ValueError("Normal distribution requires mean and stdev.")
+        return DistributionFactory.from_dict({"type": "normal", "mean": mean, "stdev": stdev})
+    if dist_type == "lognormal":
+        if mean is None or stdev is None:
+            raise ValueError("Lognormal distribution requires mean and stdev.")
+        return DistributionFactory.from_dict({"type": "lognormal", "mean": mean, "stdev": stdev})
+    if dist_type == "exponential":
+        if mean is None:
+            raise ValueError("Exponential distribution requires mean.")
+        return DistributionFactory.from_dict({"type": "exponential", "mean": mean})
+    raise ValueError(f"Unsupported distribution type '{dist_type}'.")

--- a/simulator/entities.py
+++ b/simulator/entities.py
@@ -1,0 +1,66 @@
+"""Core data structures for the process flow simulator."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Sequence
+
+from .distributions import Distribution, DistributionFactory
+
+
+@dataclass
+class Task:
+    """Represents a single workstation or task in the process line."""
+
+    name: str
+    distribution: Distribution
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Task":
+        distribution = DistributionFactory.from_dict(data["distribution"])
+        return cls(name=data.get("name", "Task"), distribution=distribution)
+
+
+@dataclass
+class ProcessLine:
+    """Represents a serial process line with intermediate buffers."""
+
+    name: str
+    tasks: Sequence[Task]
+    buffer_capacities: Sequence[Optional[int]] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        task_count = len(self.tasks)
+        expected_buffers = max(0, task_count - 1)
+        if len(self.buffer_capacities) != expected_buffers:
+            if not self.buffer_capacities:
+                self.buffer_capacities = [0 for _ in range(expected_buffers)]
+            else:
+                raise ValueError(
+                    f"Process line '{self.name}' expected {expected_buffers} buffer capacities "
+                    f"but received {len(self.buffer_capacities)}."
+                )
+
+    def describe(self) -> str:
+        parts = []
+        for idx, task in enumerate(self.tasks):
+            parts.append(task.name)
+            if idx < len(self.buffer_capacities):
+                capacity = self.buffer_capacities[idx]
+                if capacity is None:
+                    parts.append("[∞ buffer]")
+                else:
+                    parts.append(f"[B{idx+1}:{capacity}]")
+        return " -> ".join(parts)
+
+    def with_buffer_override(self, index: int, capacity: Optional[int]) -> "ProcessLine":
+        if index < 0 or index >= len(self.buffer_capacities):
+            raise IndexError("Buffer index out of range.")
+        new_buffers = list(self.buffer_capacities)
+        new_buffers[index] = capacity
+        return ProcessLine(name=f"{self.name} (buffer {index+1}={capacity})", tasks=self.tasks, buffer_capacities=new_buffers)
+
+
+def infinite_buffer() -> Optional[int]:
+    """Helper constant to represent an infinite buffer."""
+
+    return None

--- a/simulator/gui.py
+++ b/simulator/gui.py
@@ -1,0 +1,918 @@
+"""Graphical user interface for the process flow simulator."""
+from __future__ import annotations
+
+import copy
+import queue
+import threading
+import tkinter as tk
+from dataclasses import dataclass, field
+from tkinter import messagebox, simpledialog
+from typing import Dict, List, Optional
+
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+from matplotlib.figure import Figure
+from matplotlib.ticker import MaxNLocator
+from tkinter import ttk
+
+from .distributions import DistributionConfig, DistributionFactory
+from .entities import ProcessLine, Task, infinite_buffer
+from .monte_carlo import MonteCarloResult, MonteCarloSummary, run_monte_carlo, summarize_results
+
+
+@dataclass
+class TaskDefinition:
+    """Editable task definition backing the GUI."""
+
+    name: str
+    distribution_type: str
+    parameters: Dict[str, float] = field(default_factory=dict)
+
+    def describe(self) -> str:
+        try:
+            distribution = DistributionFactory.from_config(
+                DistributionConfig(type=self.distribution_type, parameters=self.parameters)
+            )
+            return distribution.description
+        except Exception:
+            return f"{self.distribution_type.title()} (?)"
+
+    def to_task(self) -> Task:
+        distribution = DistributionFactory.from_config(
+            DistributionConfig(type=self.distribution_type, parameters=self.parameters)
+        )
+        return Task(name=self.name, distribution=distribution)
+
+
+@dataclass
+class LineDefinition:
+    """Editable process line definition for the GUI."""
+
+    name: str
+    tasks: List[TaskDefinition]
+    buffers: List[Optional[int]]
+
+    def ensure_buffer_count(self) -> None:
+        expected = max(0, len(self.tasks) - 1)
+        if len(self.buffers) != expected:
+            if len(self.buffers) < expected:
+                self.buffers.extend([0] * (expected - len(self.buffers)))
+            else:
+                self.buffers = self.buffers[:expected]
+
+    def to_process_line(self) -> ProcessLine:
+        self.ensure_buffer_count()
+        return ProcessLine(
+            name=self.name,
+            tasks=[task.to_task() for task in self.tasks],
+            buffer_capacities=[None if buf is None else int(buf) for buf in self.buffers],
+        )
+
+
+def _build_sample_lines() -> Dict[str, LineDefinition]:
+    uniform = lambda mean, half_range: {
+        "type": "uniform",
+        "mean": mean,
+        "half_range": half_range,
+    }
+    line_a = LineDefinition(
+        name="Line A",
+        tasks=[
+            TaskDefinition(name=f"Task {idx+1}", distribution_type="uniform", parameters=uniform(10, 2))
+            for idx in range(6)
+        ],
+        buffers=[0] * 5,
+    )
+    line_b = LineDefinition(
+        name="Line B",
+        tasks=[
+            TaskDefinition(name="Task 1", distribution_type="uniform", parameters=uniform(6, 2)),
+            TaskDefinition(name="Task 2", distribution_type="uniform", parameters=uniform(10, 2)),
+            TaskDefinition(name="Task 3", distribution_type="uniform", parameters=uniform(4, 3)),
+            TaskDefinition(name="Task 4", distribution_type="uniform", parameters=uniform(7, 1)),
+            TaskDefinition(name="Task 5", distribution_type="uniform", parameters=uniform(5, 3)),
+            TaskDefinition(name="Task 6", distribution_type="uniform", parameters=uniform(5, 2)),
+        ],
+        buffers=[0] * 5,
+    )
+    return {line_a.name: line_a, line_b.name: line_b}
+
+
+class TaskDialog(tk.Toplevel):
+    """Dialog for creating or editing a task definition."""
+
+    def __init__(self, parent: tk.Widget, task: Optional[TaskDefinition] = None) -> None:
+        super().__init__(parent)
+        self.title("Task settings")
+        self.resizable(False, False)
+        self.result: Optional[TaskDefinition] = None
+        self.transient(parent)
+        self.grab_set()
+
+        self.name_var = tk.StringVar(value=task.name if task else "Task")
+        self.type_var = tk.StringVar(value=(task.distribution_type if task else "uniform").lower())
+
+        self.parameters: Dict[str, tk.StringVar] = {}
+
+        content = ttk.Frame(self, padding=15)
+        content.grid(row=0, column=0, sticky="nsew")
+
+        ttk.Label(content, text="Task name:").grid(row=0, column=0, sticky="w")
+        name_entry = ttk.Entry(content, textvariable=self.name_var, width=30)
+        name_entry.grid(row=0, column=1, sticky="ew")
+        name_entry.focus_set()
+
+        ttk.Label(content, text="Distribution:").grid(row=1, column=0, sticky="w")
+        combo = ttk.Combobox(
+            content,
+            textvariable=self.type_var,
+            values=["uniform", "triangular", "normal", "lognormal", "exponential"],
+            state="readonly",
+        )
+        combo.grid(row=1, column=1, sticky="ew")
+        combo.bind("<<ComboboxSelected>>", lambda _event: self._render_parameter_fields())
+
+        self.param_frame = ttk.LabelFrame(content, text="Parameters", padding=(10, 8))
+        self.param_frame.grid(row=2, column=0, columnspan=2, sticky="ew", pady=(10, 0))
+
+        button_frame = ttk.Frame(content)
+        button_frame.grid(row=3, column=0, columnspan=2, pady=(15, 0))
+        ttk.Button(button_frame, text="Cancel", command=self._on_cancel).grid(row=0, column=0, padx=5)
+        ttk.Button(button_frame, text="Save", command=self._on_save).grid(row=0, column=1, padx=5)
+
+        self.columnconfigure(0, weight=1)
+        content.columnconfigure(1, weight=1)
+
+        self._render_parameter_fields(task)
+
+    def _render_parameter_fields(self, task: Optional[TaskDefinition] = None) -> None:
+        for child in self.param_frame.winfo_children():
+            child.destroy()
+        self.parameters.clear()
+
+        dist_type = self.type_var.get().lower()
+        defaults: Dict[str, float] = {}
+        if task and task.distribution_type.lower() == dist_type:
+            defaults = task.parameters
+        field_specs = []
+        if dist_type == "uniform":
+            field_specs = [("Mean", "mean", defaults.get("mean", 10.0)), ("Half range", "half_range", defaults.get("half_range", 2.0))]
+        elif dist_type == "triangular":
+            field_specs = [
+                ("Minimum", "min", defaults.get("min", 4.0)),
+                ("Most likely", "mode", defaults.get("mode", 6.0)),
+                ("Maximum", "max", defaults.get("max", 8.0)),
+            ]
+        elif dist_type == "normal":
+            field_specs = [
+                ("Mean", "mean", defaults.get("mean", 10.0)),
+                ("Std dev", "stdev", defaults.get("stdev", 2.0)),
+            ]
+        elif dist_type == "lognormal":
+            field_specs = [
+                ("Mean", "mean", defaults.get("mean", 10.0)),
+                ("Std dev", "stdev", defaults.get("stdev", 3.0)),
+            ]
+        else:
+            field_specs = [("Mean", "mean", defaults.get("mean", 10.0))]
+
+        for row, (label, key, value) in enumerate(field_specs):
+            ttk.Label(self.param_frame, text=f"{label}:").grid(row=row, column=0, sticky="w", pady=2)
+            var = tk.StringVar(value=f"{value}")
+            entry = ttk.Entry(self.param_frame, textvariable=var, width=18)
+            entry.grid(row=row, column=1, sticky="ew", pady=2)
+            self.parameters[key] = var
+            if row == 0:
+                entry.focus_set()
+
+        self.param_frame.columnconfigure(1, weight=1)
+
+    def _on_cancel(self) -> None:
+        self.result = None
+        self.destroy()
+
+    def _on_save(self) -> None:
+        name = self.name_var.get().strip() or "Task"
+        dist_type = self.type_var.get().lower()
+        params: Dict[str, float] = {}
+        try:
+            for key, var in self.parameters.items():
+                params[key] = float(var.get())
+        except ValueError:
+            messagebox.showerror("Invalid input", "Please enter numeric values for distribution parameters.", parent=self)
+            return
+        try:
+            definition = TaskDefinition(name=name, distribution_type=dist_type, parameters=params)
+            definition.describe()  # Validate configuration
+        except Exception as exc:  # pragma: no cover - GUI validation
+            messagebox.showerror("Invalid distribution", str(exc), parent=self)
+            return
+        self.result = definition
+        self.destroy()
+
+
+class SimulatorGUI:
+    """Tkinter based application for configuring and running Monte Carlo studies."""
+
+    def __init__(self, root: tk.Tk) -> None:
+        self.root = root
+        self.root.title("Process Flow Monte Carlo Studio")
+        self.root.geometry("1200x800")
+        self.root.minsize(1000, 700)
+
+        self.lines: List[LineDefinition] = []
+        self.selected_line_index: Optional[int] = None
+        self.monte_carlo_settings = {
+            "jobs": tk.StringVar(value="500"),
+            "warmup": tk.StringVar(value="100"),
+            "sims": tk.StringVar(value="25"),
+            "seed": tk.StringVar(value=""),
+        }
+
+        self.status_var = tk.StringVar(value="Welcome! Configure your lines to begin.")
+
+        self._simulation_thread: Optional[threading.Thread] = None
+        self._simulation_queue: queue.Queue = queue.Queue()
+        self._buffer_thread: Optional[threading.Thread] = None
+        self._buffer_queue: queue.Queue = queue.Queue()
+
+        self.monte_carlo_results: List[MonteCarloResult] = []
+        self.monte_carlo_summaries: List[MonteCarloSummary] = []
+
+        self._build_widgets()
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+    def _build_widgets(self) -> None:
+        notebook = ttk.Notebook(self.root)
+        notebook.pack(fill=tk.BOTH, expand=True)
+
+        self.setup_frame = ttk.Frame(notebook, padding=15)
+        self.results_frame = ttk.Frame(notebook, padding=15)
+        notebook.add(self.setup_frame, text="Setup")
+        notebook.add(self.results_frame, text="Results")
+
+        self._build_setup_tab(self.setup_frame)
+        self._build_results_tab(self.results_frame)
+
+        status_bar = ttk.Frame(self.root)
+        status_bar.pack(fill=tk.X, side=tk.BOTTOM)
+        ttk.Label(status_bar, textvariable=self.status_var, anchor="w", padding=(10, 5)).pack(fill=tk.X)
+
+    def _build_setup_tab(self, parent: ttk.Frame) -> None:
+        parent.columnconfigure(1, weight=1)
+        parent.rowconfigure(0, weight=1)
+
+        # Left column: list of lines and actions
+        left = ttk.Frame(parent)
+        left.grid(row=0, column=0, sticky="nsw", padx=(0, 12))
+        ttk.Label(left, text="Process lines", font=("Segoe UI", 11, "bold")).pack(anchor="w")
+
+        self.lines_list = tk.Listbox(left, height=20)
+        self.lines_list.pack(fill=tk.BOTH, expand=True, pady=(6, 6))
+        self.lines_list.bind("<<ListboxSelect>>", lambda _event: self._on_line_selected())
+
+        button_frame = ttk.Frame(left)
+        button_frame.pack(fill=tk.X)
+        ttk.Button(button_frame, text="Add custom line", command=self._add_custom_line).grid(row=0, column=0, sticky="ew", pady=2)
+        ttk.Button(button_frame, text="Add Line A example", command=lambda: self._add_sample_line("Line A")).grid(row=1, column=0, sticky="ew", pady=2)
+        ttk.Button(button_frame, text="Add Line B example", command=lambda: self._add_sample_line("Line B")).grid(row=2, column=0, sticky="ew", pady=2)
+        ttk.Button(button_frame, text="Remove selected", command=self._remove_selected_line).grid(row=3, column=0, sticky="ew", pady=2)
+        button_frame.columnconfigure(0, weight=1)
+
+        # Right column: line details
+        details = ttk.Frame(parent)
+        details.grid(row=0, column=1, sticky="nsew")
+        details.columnconfigure(0, weight=1)
+        details.rowconfigure(1, weight=1)
+
+        header = ttk.Frame(details)
+        header.grid(row=0, column=0, sticky="ew")
+        header.columnconfigure(1, weight=1)
+        ttk.Label(header, text="Line name:").grid(row=0, column=0, sticky="w", padx=(0, 6))
+        self.line_name_var = tk.StringVar()
+        self.line_name_entry = ttk.Entry(header, textvariable=self.line_name_var)
+        self.line_name_entry.grid(row=0, column=1, sticky="ew")
+        self.line_name_var.trace_add("write", lambda *_: self._update_line_name())
+
+        task_frame = ttk.LabelFrame(details, text="Workstations", padding=10)
+        task_frame.grid(row=1, column=0, sticky="nsew", pady=(12, 12))
+        task_frame.columnconfigure(0, weight=1)
+        task_frame.rowconfigure(0, weight=1)
+
+        columns = ("task", "distribution", "buffer")
+        self.task_tree = ttk.Treeview(task_frame, columns=columns, show="headings", selectmode="browse")
+        self.task_tree.heading("task", text="Workstation")
+        self.task_tree.heading("distribution", text="Distribution")
+        self.task_tree.heading("buffer", text="Buffer after")
+        self.task_tree.column("task", width=180, anchor="w")
+        self.task_tree.column("distribution", width=280, anchor="w")
+        self.task_tree.column("buffer", width=120, anchor="center")
+        self.task_tree.grid(row=0, column=0, sticky="nsew")
+
+        tree_scroll = ttk.Scrollbar(task_frame, orient=tk.VERTICAL, command=self.task_tree.yview)
+        self.task_tree.configure(yscrollcommand=tree_scroll.set)
+        tree_scroll.grid(row=0, column=1, sticky="ns")
+
+        actions = ttk.Frame(task_frame)
+        actions.grid(row=1, column=0, columnspan=2, sticky="ew", pady=(10, 0))
+        actions.columnconfigure((0, 1, 2, 3, 4, 5), weight=1)
+        ttk.Button(actions, text="Add task", command=self._add_task).grid(row=0, column=0, padx=2)
+        ttk.Button(actions, text="Edit task", command=self._edit_task).grid(row=0, column=1, padx=2)
+        ttk.Button(actions, text="Remove task", command=self._remove_task).grid(row=0, column=2, padx=2)
+        ttk.Button(actions, text="Move up", command=lambda: self._move_task(-1)).grid(row=0, column=3, padx=2)
+        ttk.Button(actions, text="Move down", command=lambda: self._move_task(1)).grid(row=0, column=4, padx=2)
+        ttk.Button(actions, text="Edit buffer", command=self._edit_buffer).grid(row=0, column=5, padx=2)
+
+        sim_frame = ttk.LabelFrame(details, text="Monte Carlo settings", padding=10)
+        sim_frame.grid(row=2, column=0, sticky="ew")
+        for col in range(8):
+            sim_frame.columnconfigure(col, weight=1)
+
+        ttk.Label(sim_frame, text="Jobs to complete:").grid(row=0, column=0, sticky="w", padx=(0, 4))
+        ttk.Entry(sim_frame, textvariable=self.monte_carlo_settings["jobs"], width=10).grid(row=0, column=1, sticky="w")
+        ttk.Label(sim_frame, text="Warm-up jobs:").grid(row=0, column=2, sticky="w", padx=(12, 4))
+        ttk.Entry(sim_frame, textvariable=self.monte_carlo_settings["warmup"], width=10).grid(row=0, column=3, sticky="w")
+        ttk.Label(sim_frame, text="Simulations:").grid(row=0, column=4, sticky="w", padx=(12, 4))
+        ttk.Entry(sim_frame, textvariable=self.monte_carlo_settings["sims"], width=10).grid(row=0, column=5, sticky="w")
+        ttk.Label(sim_frame, text="Random seed:").grid(row=0, column=6, sticky="w", padx=(12, 4))
+        ttk.Entry(sim_frame, textvariable=self.monte_carlo_settings["seed"], width=10).grid(row=0, column=7, sticky="w")
+
+        ttk.Button(details, text="Run simulation", command=self._run_simulation).grid(row=3, column=0, sticky="e", pady=(10, 0))
+
+    def _build_results_tab(self, parent: ttk.Frame) -> None:
+        parent.columnconfigure(0, weight=1)
+        parent.rowconfigure(1, weight=1)
+
+        intro = ttk.Label(
+            parent,
+            text="Run a simulation to view throughput and workstation performance summaries.",
+            font=("Segoe UI", 11),
+        )
+        intro.grid(row=0, column=0, sticky="w")
+
+        summary_frame = ttk.Frame(parent)
+        summary_frame.grid(row=1, column=0, sticky="nsew", pady=(12, 0))
+        summary_frame.columnconfigure(0, weight=1)
+        summary_frame.columnconfigure(1, weight=1)
+        summary_frame.rowconfigure(1, weight=1)
+
+        tree_container = ttk.LabelFrame(summary_frame, text="Line summaries", padding=10)
+        tree_container.grid(row=0, column=0, sticky="nsew")
+        tree_container.columnconfigure(0, weight=1)
+        tree_container.rowconfigure(0, weight=1)
+
+        columns = ("throughput", "throughput_std", "cycle", "cycle_std")
+        self.summary_tree = ttk.Treeview(tree_container, columns=columns, show="headings", selectmode="browse")
+        self.summary_tree.heading("throughput", text="Throughput (jobs/min)")
+        self.summary_tree.heading("throughput_std", text="σ throughput")
+        self.summary_tree.heading("cycle", text="Avg cycle time (min)")
+        self.summary_tree.heading("cycle_std", text="σ cycle")
+        self.summary_tree.column("throughput", width=160, anchor="center")
+        self.summary_tree.column("throughput_std", width=120, anchor="center")
+        self.summary_tree.column("cycle", width=150, anchor="center")
+        self.summary_tree.column("cycle_std", width=100, anchor="center")
+        self.summary_tree.grid(row=0, column=0, sticky="nsew")
+
+        summary_scroll = ttk.Scrollbar(tree_container, orient=tk.VERTICAL, command=self.summary_tree.yview)
+        self.summary_tree.configure(yscrollcommand=summary_scroll.set)
+        summary_scroll.grid(row=0, column=1, sticky="ns")
+
+        chart_frame = ttk.LabelFrame(summary_frame, text="Throughput comparison", padding=10)
+        chart_frame.grid(row=0, column=1, sticky="nsew", padx=(12, 0))
+        chart_frame.columnconfigure(0, weight=1)
+        chart_frame.rowconfigure(0, weight=1)
+
+        self.figure = Figure(figsize=(5.5, 3.8), dpi=100)
+        self.throughput_ax = self.figure.add_subplot(111)
+        self.throughput_ax.set_xlabel("Process line")
+        self.throughput_ax.set_ylabel("Throughput (jobs/min)")
+        self.throughput_canvas = FigureCanvasTkAgg(self.figure, master=chart_frame)
+        self.throughput_canvas.get_tk_widget().grid(row=0, column=0, sticky="nsew")
+
+        detail_frame = ttk.LabelFrame(summary_frame, text="Line details", padding=10)
+        detail_frame.grid(row=1, column=0, columnspan=2, sticky="nsew", pady=(12, 0))
+        detail_frame.columnconfigure(0, weight=1)
+        detail_frame.rowconfigure(2, weight=1)
+
+        selector_frame = ttk.Frame(detail_frame)
+        selector_frame.grid(row=0, column=0, sticky="ew")
+        ttk.Label(selector_frame, text="Select line:").grid(row=0, column=0, sticky="w")
+        self.detail_line_var = tk.StringVar()
+        self.detail_line_combo = ttk.Combobox(selector_frame, textvariable=self.detail_line_var, state="readonly")
+        self.detail_line_combo.grid(row=0, column=1, sticky="w", padx=(6, 0))
+        self.detail_line_combo.bind("<<ComboboxSelected>>", lambda _event: self._refresh_station_details())
+
+        self.detail_summary_var = tk.StringVar()
+        ttk.Label(detail_frame, textvariable=self.detail_summary_var, font=("Segoe UI", 10, "bold")).grid(
+            row=1, column=0, sticky="w", pady=(6, 6)
+        )
+
+        columns = ("station", "util", "blocked", "starved")
+        self.station_tree = ttk.Treeview(detail_frame, columns=columns, show="headings")
+        self.station_tree.heading("station", text="Workstation")
+        self.station_tree.heading("util", text="Utilization %")
+        self.station_tree.heading("blocked", text="Blocked %")
+        self.station_tree.heading("starved", text="Starved %")
+        self.station_tree.column("station", width=200, anchor="w")
+        self.station_tree.column("util", width=120, anchor="center")
+        self.station_tree.column("blocked", width=120, anchor="center")
+        self.station_tree.column("starved", width=120, anchor="center")
+        self.station_tree.grid(row=2, column=0, sticky="nsew")
+
+        buffer_frame = ttk.Frame(detail_frame)
+        buffer_frame.grid(row=3, column=0, sticky="ew", pady=(10, 0))
+        ttk.Label(buffer_frame, text="Buffer capacity to evaluate:").grid(row=0, column=0, sticky="w")
+        self.buffer_capacity_var = tk.StringVar(value="1")
+        ttk.Entry(buffer_frame, textvariable=self.buffer_capacity_var, width=8).grid(row=0, column=1, sticky="w", padx=(4, 12))
+        ttk.Button(buffer_frame, text="Suggest best location", command=self._suggest_buffer_location).grid(row=0, column=2, sticky="w")
+        self.buffer_suggestion_var = tk.StringVar()
+        ttk.Label(buffer_frame, textvariable=self.buffer_suggestion_var, wraplength=800, justify="left").grid(
+            row=1, column=0, columnspan=3, sticky="w", pady=(6, 0)
+        )
+
+    # ------------------------------------------------------------------
+    # Line management helpers
+    # ------------------------------------------------------------------
+    def _add_custom_line(self) -> None:
+        default_tasks = [
+            TaskDefinition(name="Task 1", distribution_type="uniform", parameters={"mean": 10.0, "half_range": 2.0}),
+            TaskDefinition(name="Task 2", distribution_type="uniform", parameters={"mean": 10.0, "half_range": 2.0}),
+            TaskDefinition(name="Task 3", distribution_type="uniform", parameters={"mean": 10.0, "half_range": 2.0}),
+        ]
+        line = LineDefinition(name=f"Line {len(self.lines) + 1}", tasks=default_tasks, buffers=[0, 0])
+        self.lines.append(line)
+        self._refresh_line_list(select=len(self.lines) - 1)
+        self.status_var.set("Added a new custom line. Edit the workstations to match your process.")
+
+    def _add_sample_line(self, sample_name: str) -> None:
+        samples = _build_sample_lines()
+        line = samples.get(sample_name)
+        if not line:
+            messagebox.showerror("Sample not found", f"Sample line '{sample_name}' is unavailable.")
+            return
+        cloned = copy.deepcopy(line)
+        self.lines.append(cloned)
+        self._refresh_line_list(select=len(self.lines) - 1)
+        self.status_var.set(f"Loaded {sample_name}. Adjust as needed before running the simulation.")
+
+    def _remove_selected_line(self) -> None:
+        index = self.selected_line_index
+        if index is None:
+            return
+        removed = self.lines.pop(index)
+        self.selected_line_index = None
+        self._refresh_line_list()
+        self.status_var.set(f"Removed {removed.name}.")
+
+    def _refresh_line_list(self, select: Optional[int] = None) -> None:
+        self.lines_list.delete(0, tk.END)
+        for line in self.lines:
+            self.lines_list.insert(tk.END, line.name)
+        if select is not None and 0 <= select < len(self.lines):
+            self.lines_list.selection_clear(0, tk.END)
+            self.lines_list.selection_set(select)
+            self.lines_list.activate(select)
+            self.selected_line_index = select
+            self._on_line_selected()
+        elif self.lines:
+            self.lines_list.selection_set(0)
+            self.lines_list.activate(0)
+            self.selected_line_index = 0
+            self._on_line_selected()
+        else:
+            self.selected_line_index = None
+            self._clear_line_details()
+
+    def _clear_line_details(self) -> None:
+        self.line_name_var.set("")
+        for row in self.task_tree.get_children():
+            self.task_tree.delete(row)
+
+    def _on_line_selected(self) -> None:
+        selection = self.lines_list.curselection()
+        if not selection:
+            self.selected_line_index = None
+            self._clear_line_details()
+            return
+        index = selection[0]
+        self.selected_line_index = index
+        line = self.lines[index]
+        self.line_name_var.set(line.name)
+        self._refresh_task_tree(line)
+
+    def _refresh_task_tree(self, line: LineDefinition) -> None:
+        for row in self.task_tree.get_children():
+            self.task_tree.delete(row)
+        line.ensure_buffer_count()
+        for idx, task in enumerate(line.tasks):
+            buffer_value = "" if idx >= len(line.buffers) else self._format_buffer(line.buffers[idx])
+            self.task_tree.insert(
+                "",
+                tk.END,
+                iid=str(idx),
+                values=(task.name, task.describe(), buffer_value),
+            )
+
+    def _update_line_name(self) -> None:
+        if self.selected_line_index is None:
+            return
+        line = self.lines[self.selected_line_index]
+        line.name = self.line_name_var.get().strip() or f"Line {self.selected_line_index + 1}"
+        self.lines_list.delete(self.selected_line_index)
+        self.lines_list.insert(self.selected_line_index, line.name)
+        self.lines_list.selection_set(self.selected_line_index)
+        self.lines_list.activate(self.selected_line_index)
+        self.status_var.set(f"Updated line name to {line.name}.")
+
+    def _add_task(self) -> None:
+        if self.selected_line_index is None:
+            return
+        dialog = TaskDialog(self.root)
+        self.root.wait_window(dialog)
+        if dialog.result:
+            line = self.lines[self.selected_line_index]
+            line.tasks.append(dialog.result)
+            line.ensure_buffer_count()
+            self._refresh_task_tree(line)
+            self.status_var.set(f"Added {dialog.result.name} to {line.name}.")
+
+    def _edit_task(self) -> None:
+        if self.selected_line_index is None:
+            return
+        selected = self.task_tree.selection()
+        if not selected:
+            messagebox.showinfo("Select a task", "Please choose a workstation to edit.")
+            return
+        index = int(selected[0])
+        line = self.lines[self.selected_line_index]
+        dialog = TaskDialog(self.root, line.tasks[index])
+        self.root.wait_window(dialog)
+        if dialog.result:
+            line.tasks[index] = dialog.result
+            self._refresh_task_tree(line)
+            self.status_var.set(f"Updated {dialog.result.name}.")
+
+    def _remove_task(self) -> None:
+        if self.selected_line_index is None:
+            return
+        selected = self.task_tree.selection()
+        if not selected:
+            return
+        index = int(selected[0])
+        line = self.lines[self.selected_line_index]
+        if len(line.tasks) <= 1:
+            messagebox.showinfo("Cannot remove", "A line must have at least one workstation.")
+            return
+        removed = line.tasks.pop(index)
+        line.ensure_buffer_count()
+        self._refresh_task_tree(line)
+        self.status_var.set(f"Removed {removed.name}.")
+
+    def _move_task(self, direction: int) -> None:
+        if self.selected_line_index is None:
+            return
+        selected = self.task_tree.selection()
+        if not selected:
+            return
+        index = int(selected[0])
+        new_index = index + direction
+        line = self.lines[self.selected_line_index]
+        if new_index < 0 or new_index >= len(line.tasks):
+            return
+        line.tasks[index], line.tasks[new_index] = line.tasks[new_index], line.tasks[index]
+        line.ensure_buffer_count()
+        self._refresh_task_tree(line)
+        self.task_tree.selection_set(str(new_index))
+        self.status_var.set(f"Moved {line.tasks[new_index].name}.")
+
+    def _edit_buffer(self) -> None:
+        if self.selected_line_index is None:
+            return
+        selected = self.task_tree.selection()
+        if not selected:
+            messagebox.showinfo("Select location", "Choose the workstation before the buffer to edit.")
+            return
+        index = int(selected[0])
+        line = self.lines[self.selected_line_index]
+        line.ensure_buffer_count()
+        if index >= len(line.buffers):
+            messagebox.showinfo("No buffer", "There is no buffer after the last workstation.")
+            return
+        current = line.buffers[index]
+        default = "inf" if current is None else str(current)
+        response = simpledialog.askstring(
+            "Buffer capacity",
+            "Enter 0 for none, a positive integer for limited storage, or 'inf' for unlimited:",
+            initialvalue=default,
+            parent=self.root,
+        )
+        if response is None:
+            return
+        response = response.strip().lower()
+        if response in {"inf", "infinite", "infinity"}:
+            line.buffers[index] = infinite_buffer()
+        else:
+            try:
+                value = int(float(response))
+                if value < 0:
+                    raise ValueError
+                line.buffers[index] = value
+            except ValueError:
+                messagebox.showerror("Invalid value", "Please enter 'inf' or a non-negative integer.")
+                return
+        self._refresh_task_tree(line)
+        self.status_var.set(
+            f"Updated buffer between {line.tasks[index].name} and {line.tasks[index + 1].name} to {self._format_buffer(line.buffers[index])}."
+        )
+
+    # ------------------------------------------------------------------
+    # Simulation execution
+    # ------------------------------------------------------------------
+    def _parse_positive_int(self, value: str, field: str, minimum: int = 1) -> Optional[int]:
+        try:
+            parsed = int(float(value))
+            if parsed < minimum:
+                raise ValueError
+            return parsed
+        except ValueError:
+            messagebox.showerror("Invalid input", f"{field} must be an integer ≥ {minimum}.")
+            return None
+
+    def _parse_non_negative_int(self, value: str, field: str) -> Optional[int]:
+        try:
+            parsed = int(float(value))
+            if parsed < 0:
+                raise ValueError
+            return parsed
+        except ValueError:
+            messagebox.showerror("Invalid input", f"{field} must be a non-negative integer.")
+            return None
+
+    def _run_simulation(self) -> None:
+        if self._simulation_thread and self._simulation_thread.is_alive():
+            return
+        if not self.lines:
+            messagebox.showinfo("Add a line", "Please add at least one process line before running a simulation.")
+            return
+        jobs = self._parse_positive_int(self.monte_carlo_settings["jobs"].get(), "Jobs to complete")
+        if jobs is None:
+            return
+        warmup = self._parse_non_negative_int(self.monte_carlo_settings["warmup"].get(), "Warm-up jobs")
+        if warmup is None:
+            return
+        sims = self._parse_positive_int(self.monte_carlo_settings["sims"].get(), "Simulations")
+        if sims is None:
+            return
+        seed_text = self.monte_carlo_settings["seed"].get().strip()
+        seed = None
+        if seed_text:
+            try:
+                seed = int(seed_text)
+            except ValueError:
+                messagebox.showerror("Invalid seed", "Random seed must be an integer or left blank.")
+                return
+
+        self.status_var.set("Running simulations...")
+        self._simulation_queue = queue.Queue()
+        self._simulation_thread = threading.Thread(
+            target=self._execute_simulation,
+            args=(jobs, warmup, sims, seed),
+            daemon=True,
+        )
+        self._simulation_thread.start()
+        self.root.after(100, self._check_simulation)
+
+    def _execute_simulation(self, jobs: int, warmup: int, sims: int, seed: Optional[int]) -> None:
+        results: List[MonteCarloResult] = []
+        try:
+            for line in self.lines:
+                process_line = line.to_process_line()
+                result = run_monte_carlo(
+                    process_line,
+                    jobs_to_complete=jobs,
+                    warmup_jobs=warmup,
+                    simulations=sims,
+                    base_seed=seed,
+                )
+                results.append(result)
+        except Exception as exc:  # pragma: no cover - safeguards runtime errors
+            self._simulation_queue.put(exc)
+            return
+        self._simulation_queue.put(results)
+
+    def _check_simulation(self) -> None:
+        if self._simulation_thread and self._simulation_thread.is_alive():
+            self.root.after(100, self._check_simulation)
+            return
+        try:
+            payload = self._simulation_queue.get_nowait()
+        except queue.Empty:
+            self.root.after(100, self._check_simulation)
+            return
+        if isinstance(payload, Exception):
+            messagebox.showerror("Simulation error", str(payload))
+            self.status_var.set("Simulation failed. Adjust your configuration and try again.")
+            return
+        self.monte_carlo_results = payload
+        self.monte_carlo_summaries = summarize_results(self.monte_carlo_results)
+        self._refresh_results_tab()
+        self.status_var.set("Simulation complete. Review the results tab for insights.")
+
+    # ------------------------------------------------------------------
+    # Results presentation
+    # ------------------------------------------------------------------
+    def _refresh_results_tab(self) -> None:
+        for row in self.summary_tree.get_children():
+            self.summary_tree.delete(row)
+        names = []
+        throughputs = []
+        errors = []
+        for summary in self.monte_carlo_summaries:
+            names.append(summary.line_name)
+            throughputs.append(summary.throughput_mean)
+            errors.append(summary.throughput_std)
+            self.summary_tree.insert(
+                "",
+                tk.END,
+                iid=summary.line_name,
+                values=(
+                    f"{summary.throughput_mean:.3f}",
+                    f"{summary.throughput_std:.3f}",
+                    f"{summary.cycle_time_mean:.3f}",
+                    f"{summary.cycle_time_std:.3f}",
+                ),
+            )
+        self._update_throughput_chart(names, throughputs, errors)
+        self.detail_line_combo["values"] = names
+        if names:
+            self.detail_line_combo.current(0)
+            self._refresh_station_details()
+        else:
+            self.detail_line_combo.set("")
+            self.detail_summary_var.set("")
+            for row in self.station_tree.get_children():
+                self.station_tree.delete(row)
+
+    def _update_throughput_chart(self, names: List[str], values: List[float], errors: List[float]) -> None:
+        self.throughput_ax.clear()
+        if names:
+            indices = range(len(names))
+            bars = self.throughput_ax.bar(indices, values, yerr=errors, capsize=6, color="#4C78A8")
+            self.throughput_ax.set_xticks(indices)
+            self.throughput_ax.set_xticklabels(names, rotation=15, ha="right")
+            self.throughput_ax.set_ylabel("Throughput (jobs/min)")
+            self.throughput_ax.yaxis.set_major_locator(MaxNLocator(5))
+            for bar, value in zip(bars, values):
+                height = bar.get_height()
+                self.throughput_ax.annotate(
+                    f"{value:.2f}",
+                    xy=(bar.get_x() + bar.get_width() / 2, height),
+                    xytext=(0, 6),
+                    textcoords="offset points",
+                    ha="center",
+                    va="bottom",
+                    fontsize=9,
+                )
+        else:
+            self.throughput_ax.text(0.5, 0.5, "Run a simulation to view results", ha="center", va="center")
+        self.throughput_ax.margins(x=0.05)
+        self.throughput_canvas.draw_idle()
+
+    def _refresh_station_details(self) -> None:
+        line_name = self.detail_line_var.get()
+        summary = next((s for s in self.monte_carlo_summaries if s.line_name == line_name), None)
+        if not summary:
+            return
+        self.detail_summary_var.set(
+            f"Throughput {summary.throughput_mean:.3f} jobs/min (σ {summary.throughput_std:.3f}) | "
+            f"Cycle time {summary.cycle_time_mean:.3f} min"
+        )
+        for row in self.station_tree.get_children():
+            self.station_tree.delete(row)
+        for station, util in summary.station_utilization.items():
+            blocked = summary.station_blocked.get(station, 0.0)
+            starved = summary.station_starved.get(station, 0.0)
+            self.station_tree.insert(
+                "",
+                tk.END,
+                values=(
+                    station,
+                    f"{util * 100:.1f}",
+                    f"{blocked * 100:.1f}",
+                    f"{starved * 100:.1f}",
+                ),
+            )
+
+    # ------------------------------------------------------------------
+    # Buffer suggestion helper
+    # ------------------------------------------------------------------
+    def _suggest_buffer_location(self) -> None:
+        if self._buffer_thread and self._buffer_thread.is_alive():
+            return
+        if self.selected_line_index is None:
+            messagebox.showinfo("Select a line", "Select a line on the setup tab to evaluate buffer locations.")
+            return
+        line = self.lines[self.selected_line_index]
+        if len(line.tasks) < 2:
+            messagebox.showinfo("Not enough tasks", "Add at least two workstations to analyze buffer placement.")
+            return
+        capacity_text = self.buffer_capacity_var.get().strip()
+        try:
+            capacity = int(float(capacity_text))
+            if capacity <= 0:
+                raise ValueError
+        except ValueError:
+            messagebox.showerror("Invalid capacity", "Enter a positive integer capacity for the new buffer.")
+            return
+        jobs = self._parse_positive_int(self.monte_carlo_settings["jobs"].get(), "Jobs to complete")
+        warmup = self._parse_non_negative_int(self.monte_carlo_settings["warmup"].get(), "Warm-up jobs")
+        sims = self._parse_positive_int(self.monte_carlo_settings["sims"].get(), "Simulations")
+        if jobs is None or warmup is None or sims is None:
+            return
+        seed_text = self.monte_carlo_settings["seed"].get().strip()
+        seed = int(seed_text) if seed_text else None
+
+        self.buffer_suggestion_var.set("Evaluating buffer locations...")
+        self._buffer_queue = queue.Queue()
+        self._buffer_thread = threading.Thread(
+            target=self._execute_buffer_study,
+            args=(line, capacity, jobs, warmup, sims, seed),
+            daemon=True,
+        )
+        self._buffer_thread.start()
+        self.root.after(100, self._check_buffer_study)
+
+    def _execute_buffer_study(
+        self,
+        line: LineDefinition,
+        capacity: int,
+        jobs: int,
+        warmup: int,
+        sims: int,
+        seed: Optional[int],
+    ) -> None:
+        try:
+            base_line = line.to_process_line()
+            base_summary = MonteCarloSummary.from_result(
+                run_monte_carlo(base_line, jobs_to_complete=jobs, warmup_jobs=warmup, simulations=sims, base_seed=seed)
+            )
+            best_delta = float("-inf")
+            best_index = None
+            messages = []
+            for idx in range(len(line.tasks) - 1):
+                modified = base_line.with_buffer_override(idx, capacity)
+                summary = MonteCarloSummary.from_result(
+                    run_monte_carlo(modified, jobs_to_complete=jobs, warmup_jobs=warmup, simulations=sims, base_seed=seed)
+                )
+                delta = summary.throughput_mean - base_summary.throughput_mean
+                before = line.tasks[idx].name
+                after = line.tasks[idx + 1].name
+                messages.append(
+                    f"Between {before} and {after}: throughput {summary.throughput_mean:.3f} (Δ {delta:+.3f})"
+                )
+                if delta > best_delta:
+                    best_delta = delta
+                    best_index = idx
+            if best_index is None or best_delta <= 1e-6:
+                result_text = "No buffer location provided a meaningful improvement."
+            else:
+                before = line.tasks[best_index].name
+                after = line.tasks[best_index + 1].name
+                result_text = (
+                    f"Suggested location: between {before} and {after} (Δ throughput {best_delta:+.3f} jobs/min)."
+                )
+            final = "\n".join(messages + ["", result_text])
+            self._buffer_queue.put(final)
+        except Exception as exc:  # pragma: no cover - runtime guard
+            self._buffer_queue.put(f"Buffer study failed: {exc}")
+
+    def _check_buffer_study(self) -> None:
+        if self._buffer_thread and self._buffer_thread.is_alive():
+            self.root.after(100, self._check_buffer_study)
+            return
+        try:
+            message = self._buffer_queue.get_nowait()
+        except queue.Empty:
+            self.root.after(100, self._check_buffer_study)
+            return
+        self.buffer_suggestion_var.set(message)
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _format_buffer(value: Optional[int]) -> str:
+        if value is None:
+            return "∞"
+        return str(value)
+
+
+def launch() -> None:
+    root = tk.Tk()
+    SimulatorGUI(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    launch()

--- a/simulator/monte_carlo.py
+++ b/simulator/monte_carlo.py
@@ -1,0 +1,86 @@
+"""Monte Carlo utilities for running repeated simulations."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import mean, pstdev
+from typing import Dict, Iterable, List, Optional
+
+from .entities import ProcessLine
+from .simulation import SimulationConfig, SimulationRunResult, simulate_line
+
+
+@dataclass
+class MonteCarloResult:
+    """Stores the collection of individual simulation runs for a line."""
+
+    line_name: str
+    runs: List[SimulationRunResult]
+
+    def metric_series(self, accessor) -> List[float]:
+        return [accessor(run) for run in self.runs]
+
+
+@dataclass
+class MonteCarloSummary:
+    """Aggregated Monte Carlo statistics."""
+
+    line_name: str
+    throughput_mean: float
+    throughput_std: float
+    cycle_time_mean: float
+    cycle_time_std: float
+    station_utilization: Dict[str, float]
+    station_blocked: Dict[str, float]
+    station_starved: Dict[str, float]
+
+    @classmethod
+    def from_result(cls, result: MonteCarloResult) -> "MonteCarloSummary":
+        throughput_values = result.metric_series(lambda run: run.throughput_rate)
+        cycle_values = result.metric_series(lambda run: run.average_cycle_time)
+        throughput_mean = mean(throughput_values) if throughput_values else 0.0
+        throughput_std = pstdev(throughput_values) if len(throughput_values) > 1 else 0.0
+        cycle_mean = mean(cycle_values) if cycle_values else 0.0
+        cycle_std = pstdev(cycle_values) if len(cycle_values) > 1 else 0.0
+
+        station_utilization: Dict[str, List[float]] = {}
+        station_blocked: Dict[str, List[float]] = {}
+        station_starved: Dict[str, List[float]] = {}
+        for run in result.runs:
+            for stats in run.station_stats:
+                station_utilization.setdefault(stats.name, []).append(stats.utilization)
+                station_blocked.setdefault(stats.name, []).append(stats.blocked_ratio)
+                station_starved.setdefault(stats.name, []).append(stats.starved_ratio)
+
+        util_avg = {name: mean(values) for name, values in station_utilization.items()}
+        blocked_avg = {name: mean(values) for name, values in station_blocked.items()}
+        starved_avg = {name: mean(values) for name, values in station_starved.items()}
+
+        return cls(
+            line_name=result.line_name,
+            throughput_mean=throughput_mean,
+            throughput_std=throughput_std,
+            cycle_time_mean=cycle_mean,
+            cycle_time_std=cycle_std,
+            station_utilization=util_avg,
+            station_blocked=blocked_avg,
+            station_starved=starved_avg,
+        )
+
+
+def run_monte_carlo(
+    line: ProcessLine,
+    jobs_to_complete: int,
+    warmup_jobs: int,
+    simulations: int,
+    base_seed: Optional[int] = None,
+) -> MonteCarloResult:
+    runs: List[SimulationRunResult] = []
+    for i in range(simulations):
+        seed = None if base_seed is None else base_seed + i
+        config = SimulationConfig(jobs_to_complete=jobs_to_complete, warmup_jobs=warmup_jobs, random_seed=seed)
+        runs.append(simulate_line(line, config))
+    return MonteCarloResult(line_name=line.name, runs=runs)
+
+
+def summarize_results(results: Iterable[MonteCarloResult]) -> List[MonteCarloSummary]:
+    return [MonteCarloSummary.from_result(result) for result in results]

--- a/simulator/simulation.py
+++ b/simulator/simulation.py
@@ -1,0 +1,288 @@
+"""Discrete event simulation engine for the process flow lines."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import heapq
+import random
+from typing import Deque, Dict, List, Optional, Tuple
+from collections import deque
+
+from .entities import ProcessLine
+
+
+@dataclass
+class StationStats:
+    """Holds time-based statistics for a single station."""
+
+    name: str
+    processing_time: float
+    blocked_time: float
+    starved_time: float
+    measured_time: float
+
+    @property
+    def utilization(self) -> float:
+        return self.processing_time / self.measured_time if self.measured_time else 0.0
+
+    @property
+    def blocked_ratio(self) -> float:
+        return self.blocked_time / self.measured_time if self.measured_time else 0.0
+
+    @property
+    def starved_ratio(self) -> float:
+        return self.starved_time / self.measured_time if self.measured_time else 0.0
+
+
+@dataclass
+class SimulationRunResult:
+    """Output of a single simulation run."""
+
+    throughput_rate: float
+    average_cycle_time: float
+    completed_jobs: int
+    measurement_start: float
+    measurement_end: float
+    station_stats: List[StationStats]
+
+    @property
+    def elapsed_time(self) -> float:
+        return self.measurement_end - self.measurement_start
+
+
+@dataclass
+class _StationState:
+    """Internal mutable state for each station during the simulation."""
+
+    name: str
+    status: str = "idle"  # idle, processing, blocked
+    current_job: Optional[int] = None
+    blocked_job: Optional[int] = None
+    last_state_change: float = 0.0
+    time_in_state: Dict[str, float] = None
+
+    def __post_init__(self) -> None:
+        if self.time_in_state is None:
+            self.time_in_state = {"processing": 0.0, "blocked": 0.0, "idle": 0.0}
+
+
+@dataclass
+class _BufferState:
+    capacity: Optional[int]
+    queue: Deque[Tuple[int, float]]
+
+    def __post_init__(self) -> None:
+        if self.queue is None:
+            self.queue = deque()
+
+    def has_space(self) -> bool:
+        if self.capacity is None:
+            return True
+        return len(self.queue) < self.capacity
+
+
+class _EventQueue:
+    def __init__(self) -> None:
+        self._queue: List[Tuple[float, int, int, int]] = []
+        self._counter = 0
+
+    def push(self, time: float, station_index: int, job_id: int) -> None:
+        heapq.heappush(self._queue, (time, self._counter, station_index, job_id))
+        self._counter += 1
+
+    def pop(self) -> Tuple[float, int, int, int]:
+        return heapq.heappop(self._queue)
+
+    def __bool__(self) -> bool:
+        return bool(self._queue)
+
+
+@dataclass
+class SimulationConfig:
+    jobs_to_complete: int
+    warmup_jobs: int
+    random_seed: Optional[int] = None
+
+
+def simulate_line(line: ProcessLine, config: SimulationConfig) -> SimulationRunResult:
+    rng = random.Random(config.random_seed)
+    station_states: List[_StationState] = [_StationState(task.name) for task in line.tasks]
+    buffer_states: List[_BufferState] = [
+        _BufferState(capacity=cap, queue=deque()) for cap in line.buffer_capacities
+    ]
+    events = _EventQueue()
+
+    total_jobs_needed = config.jobs_to_complete + config.warmup_jobs
+    jobs_started = 0
+    jobs_completed = 0
+    measurement_started = False
+    measurement_start_time = 0.0
+    last_completion_time = 0.0
+    job_entry_times: Dict[int, float] = {}
+    recorded_cycle_times: List[float] = []
+
+    def record_state_duration(index: int, current_time: float) -> None:
+        station = station_states[index]
+        if not measurement_started:
+            station.last_state_change = current_time
+            return
+        elapsed = current_time - station.last_state_change
+        if elapsed < 0:
+            return
+        station.time_in_state[station.status] += elapsed
+        station.last_state_change = current_time
+
+    def change_status(index: int, new_status: str, current_time: float) -> None:
+        record_state_duration(index, current_time)
+        station_states[index].status = new_status
+        station_states[index].last_state_change = current_time
+
+    def start_processing(index: int, job_id: int, current_time: float) -> None:
+        station = station_states[index]
+        change_status(index, "processing", current_time)
+        station.current_job = job_id
+        duration = line.tasks[index].distribution.sample(rng)
+        completion_time = current_time + max(0.0, duration)
+        events.push(completion_time, index, job_id)
+
+    def attempt_start(index: int, current_time: float) -> None:
+        station = station_states[index]
+        if station.status != "idle":
+            return
+        if index == 0:
+            nonlocal jobs_started
+            if jobs_started >= total_jobs_needed:
+                return
+            job_id = jobs_started
+            jobs_started += 1
+            job_entry_times[job_id] = current_time
+            start_processing(index, job_id, current_time)
+            return
+        buffer = buffer_states[index - 1]
+        if buffer.capacity == 0:
+            prev_station = station_states[index - 1]
+            if prev_station.status == "blocked" and prev_station.blocked_job is not None:
+                job_id = prev_station.blocked_job
+                prev_station.blocked_job = None
+                change_status(index - 1, "idle", current_time)
+                start_processing(index, job_id, current_time)
+                attempt_start(index - 1, current_time)
+            return
+        if buffer.queue:
+            job_id, _ = buffer.queue.popleft()
+            start_processing(index, job_id, current_time)
+            prev_station = station_states[index - 1]
+            if prev_station.status == "blocked" and prev_station.blocked_job is not None and buffer.has_space():
+                pending_job = prev_station.blocked_job
+                prev_station.blocked_job = None
+                change_status(index - 1, "idle", current_time)
+                buffer.queue.append((pending_job, current_time))
+                attempt_start(index - 1, current_time)
+            return
+        change_status(index, "idle", current_time)
+
+    def release_blocked_station(index: int, current_time: float) -> None:
+        station = station_states[index]
+        if station.status != "blocked" or station.blocked_job is None:
+            return
+        next_index = index + 1
+        buffer = buffer_states[index]
+        if buffer.capacity == 0:
+            next_station = station_states[next_index]
+            if next_station.status == "idle":
+                job_id = station.blocked_job
+                station.blocked_job = None
+                change_status(index, "idle", current_time)
+                start_processing(next_index, job_id, current_time)
+                attempt_start(index, current_time)
+            return
+        if buffer.has_space():
+            job_id = station.blocked_job
+            station.blocked_job = None
+            change_status(index, "idle", current_time)
+            buffer.queue.append((job_id, current_time))
+            attempt_start(index, current_time)
+            attempt_start(index + 1, current_time)
+
+    def handle_completion(index: int, job_id: int, current_time: float) -> None:
+        nonlocal jobs_completed, measurement_started, measurement_start_time, last_completion_time
+        station = station_states[index]
+        if station.current_job != job_id:
+            return
+        station.current_job = None
+        change_status(index, "idle", current_time)
+        next_index = index + 1
+        if next_index >= len(station_states):
+            jobs_completed += 1
+            last_completion_time = current_time
+            if jobs_completed == config.warmup_jobs:
+                measurement_started = True
+                measurement_start_time = current_time
+                for idx in range(len(station_states)):
+                    station_states[idx].time_in_state = {"processing": 0.0, "blocked": 0.0, "idle": 0.0}
+                    station_states[idx].last_state_change = current_time
+                    station_states[idx].status = station_states[idx].status
+            if jobs_completed > config.warmup_jobs:
+                cycle_time = current_time - job_entry_times[job_id]
+                recorded_cycle_times.append(cycle_time)
+            change_status(index, "idle", current_time)
+            attempt_start(index, current_time)
+            if index > 0 and line.buffer_capacities[index - 1] == 0:
+                release_blocked_station(index - 1, current_time)
+            return
+        buffer = buffer_states[index]
+        if buffer.capacity == 0:
+            next_station = station_states[next_index]
+            if next_station.status == "idle":
+                start_processing(next_index, job_id, current_time)
+                attempt_start(index, current_time)
+            else:
+                station.blocked_job = job_id
+                change_status(index, "blocked", current_time)
+            return
+        if buffer.has_space():
+            buffer.queue.append((job_id, current_time))
+            attempt_start(next_index, current_time)
+            attempt_start(index, current_time)
+        else:
+            station.blocked_job = job_id
+            change_status(index, "blocked", current_time)
+
+    attempt_start(0, 0.0)
+
+    while events and jobs_completed < total_jobs_needed:
+        time, _, station_index, job_id = events.pop()
+        handle_completion(station_index, job_id, time)
+
+    end_time = last_completion_time
+    if not measurement_started:
+        measurement_start_time = 0.0
+        measurement_duration = end_time - measurement_start_time
+    else:
+        measurement_duration = end_time - measurement_start_time
+
+    station_summaries: List[StationStats] = []
+    for idx, station in enumerate(station_states):
+        record_state_duration(idx, end_time)
+        stats = StationStats(
+            name=station.name,
+            processing_time=station.time_in_state.get("processing", 0.0),
+            blocked_time=station.time_in_state.get("blocked", 0.0),
+            starved_time=station.time_in_state.get("idle", 0.0),
+            measured_time=measurement_duration,
+        )
+        station_summaries.append(stats)
+
+    throughput = 0.0
+    avg_cycle_time = 0.0
+    if measurement_duration > 0 and recorded_cycle_times:
+        throughput = len(recorded_cycle_times) / measurement_duration
+        avg_cycle_time = sum(recorded_cycle_times) / len(recorded_cycle_times)
+
+    return SimulationRunResult(
+        throughput_rate=throughput,
+        average_cycle_time=avg_cycle_time,
+        completed_jobs=len(recorded_cycle_times),
+        measurement_start=measurement_start_time,
+        measurement_end=end_time,
+        station_stats=station_summaries,
+    )


### PR DESCRIPTION
## Summary
- add a Tkinter-based GUI for configuring lines, running Monte Carlo studies, and visualizing results with charts and tables
- expose the new GUI through the run_simulator entry point and document the workflow and dependencies
- capture the matplotlib dependency in requirements.txt while keeping the original CLI available for reference

## Testing
- python -m compileall simulator run_simulator.py

------
https://chatgpt.com/codex/tasks/task_e_68df0173b01483308d7baec15e858e57